### PR TITLE
Move LandingGate into hibocare-website and wrap App

### DIFF
--- a/hibocare-website/.env
+++ b/hibocare-website/.env
@@ -1,0 +1,2 @@
+VITE_GATE_BYPASS=false
+VITE_FORM_ENDPOINT=https://formspree.io/f/xdklgnnp

--- a/hibocare-website/.env.example
+++ b/hibocare-website/.env.example
@@ -1,0 +1,2 @@
+VITE_GATE_BYPASS=false
+VITE_FORM_ENDPOINT=https://formspree.io/f/xdklgnnp

--- a/hibocare-website/src/features/gate/Gate.jsx
+++ b/hibocare-website/src/features/gate/Gate.jsx
@@ -1,0 +1,8 @@
+import LandingGate from './LandingGate'
+
+const bypass = String(import.meta.env.VITE_GATE_BYPASS) === 'true'
+
+export default function Gate({ children }) {
+  if (bypass) return children
+  return <LandingGate>{children}</LandingGate>
+}

--- a/hibocare-website/src/features/gate/LandingGate.jsx
+++ b/hibocare-website/src/features/gate/LandingGate.jsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+
+export default function LandingGate({ children }) {
+  const [open, setOpen] = useState(false)
+  const endpoint = import.meta.env.VITE_FORM_ENDPOINT
+
+  if (open) return children
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    setOpen(true)
+  }
+
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h1>Welcome</h1>
+      <form action={endpoint} method="POST" onSubmit={handleSubmit}>
+        <button type="submit">Enter</button>
+      </form>
+    </div>
+  )
+}

--- a/hibocare-website/src/main.jsx
+++ b/hibocare-website/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import Gate from './features/gate/Gate'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <Gate>
+      <App />
+    </Gate>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- move LandingGate and Gate components into hibocare-website
- wrap App with Gate in main entry
- add env files for gate configuration

## Testing
- `pnpm i`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b31bbc555c832b849ce0b33b321ffe