### PR TITLE
feat: gate TTL and updated landing copy

### DIFF
--- a/hibocare-website/.env
+++ b/hibocare-website/.env
@@ -1,2 +1,3 @@
 VITE_GATE_BYPASS=false
 VITE_FORM_ENDPOINT=https://formspree.io/f/xdklgnnp
+VITE_GATE_TTL_DAYS=30

--- a/hibocare-website/.env.example
+++ b/hibocare-website/.env.example
@@ -1,2 +1,3 @@
 VITE_GATE_BYPASS=false
 VITE_FORM_ENDPOINT=https://formspree.io/f/xdklgnnp
+VITE_GATE_TTL_DAYS=30

--- a/hibocare-website/src/features/gate/Gate.jsx
+++ b/hibocare-website/src/features/gate/Gate.jsx
@@ -1,12 +1,28 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import LandingGate from './LandingGate'
 
-const bypass = String(import.meta.env.VITE_GATE_BYPASS) === 'true'
+const days = Number(import.meta.env.VITE_GATE_TTL_DAYS ?? 30)
+const ttlMs = days * 864e5
+
+window.clearGate = () =>
+  ['gate_ok', 'gate_name', 'gate_email', 'gate_until'].forEach(k =>
+    localStorage.removeItem(k)
+  )
 
 export default function Gate({ children }) {
-  const [ok, setOk] = useState(() =>
-    bypass || localStorage.getItem('gate_ok') === '1'
-  )
+  const [ok, setOk] = useState(false)
+
+  useEffect(() => {
+    const bypass = import.meta.env.VITE_GATE_BYPASS === 'true'
+    const storedOk = localStorage.getItem('gate_ok') === '1'
+    const until = parseInt(localStorage.getItem('gate_until') || '0', 10)
+    const allowed = storedOk && until > Date.now()
+
+    if (allowed) {
+      localStorage.setItem('gate_until', String(Date.now() + ttlMs))
+    }
+    setOk(bypass || allowed)
+  }, [])
 
   if (ok) return children
   return <LandingGate onSuccess={() => setOk(true)} />

--- a/hibocare-website/src/features/gate/LandingGate.jsx
+++ b/hibocare-website/src/features/gate/LandingGate.jsx
@@ -7,6 +7,9 @@ export default function LandingGate({ onSuccess }) {
   const [submitted, setSubmitted] = useState(false)
   const [touched, setTouched] = useState({ first: false, last: false, email: false })
 
+  const days = Number(import.meta.env.VITE_GATE_TTL_DAYS ?? 30)
+  const ttlMs = days * 864e5
+
   const firstNameError = firstName.trim().length >= 2 ? '' : 'Please enter your first name'
   const lastNameError = lastName.trim().length >= 2 ? '' : 'Please enter your last name'
   const emailError = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())
@@ -38,7 +41,7 @@ export default function LandingGate({ onSuccess }) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
         })
-      } catch (_) {
+      } catch {
         // ignore network failure
       }
     }
@@ -46,6 +49,7 @@ export default function LandingGate({ onSuccess }) {
     localStorage.setItem('gate_ok', '1')
     localStorage.setItem('gate_name', `${firstName} ${lastName}`.trim())
     localStorage.setItem('gate_email', email)
+    localStorage.setItem('gate_until', String(Date.now() + ttlMs))
 
     if (onSuccess) onSuccess()
     else location.reload()
@@ -59,9 +63,9 @@ export default function LandingGate({ onSuccess }) {
         onSubmit={handleSubmit}
         style={{ width: '100%', maxWidth: 420, background: '#fff', padding: '2rem', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.1)' }}
       >
-        <h1 style={{ marginBottom: '0.5rem' }}>Welcome to HiboCare</h1>
+        <h1 style={{ marginBottom: '0.5rem' }}>Welcome to HiboScreen</h1>
         <p style={{ marginBottom: '1rem', color: '#555' }}>
-          To visit the HiboScreen website, please enter your name and email address.
+          Please enter your details to continue
         </p>
         <div style={{ marginBottom: '1rem' }}>
           <input
@@ -107,10 +111,10 @@ export default function LandingGate({ onSuccess }) {
           disabled={!isValid}
           style={{ width: '100%', padding: '0.75rem', cursor: isValid ? 'pointer' : 'not-allowed' }}
         >
-          Enter
+          Enter site
         </button>
         <p style={{ marginTop: '1rem', fontSize: '0.8rem', color: '#666' }}>
-          We’ll only use your details to follow up on your interest in HiboScreen.
+          We’ll only use this to contact you about HiboScreen. No spam.
         </p>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- remember visitors with `VITE_GATE_TTL_DAYS` sliding expiration
- improve landing gate copy and persist first/last name & email
- add `window.clearGate()` helper to reset stored gate data

## Testing
- `pnpm -C hibocare-website lint` *(fails: 'lifestyleImage' is defined but never used, '__dirname' is not defined)*
- `pnpm -C hibocare-website build`


------
https://chatgpt.com/codex/tasks/task_e_68b8110fbdc4832bb942f89e1cd523a1