### PR TITLE
feat(info): add Request More Info modal with Formspree submit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Optional: separate endpoint for the “Request More Info” form.
+# If not set, the app will fall back to VITE_FORM_ENDPOINT.
+VITE_INFO_FORM_ENDPOINT=https://formspree.io/f/xjkepbgp

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,8 @@ import DataCentersModal from './features/industries/DataCentersModal';
 import HospitalsModal from './features/industries/HospitalsModal';
 import GreenhousesModal from './features/industries/GreenhousesModal';
 import CommercialBuildingsModal from './features/industries/CommercialBuildingsModal';
+import { InfoRequestProvider, useInfoRequest } from "@/features/info/InfoRequestContext";
+import InfoRequestModal from "@/features/info/InfoRequestModal";
 import { 
   Wind, 
   DollarSign, 
@@ -38,6 +40,7 @@ import heroFiltersImage from './assets/hero_filters_original.jpeg';
 
 function HomePage() {
   const [selectedApplication, setSelectedApplication] = useState(null);
+  const { open } = useInfoRequest();
 
   return (
     <>
@@ -67,8 +70,12 @@ function HomePage() {
                 </p>
               </div>
               <div className="flex flex-col sm:flex-row gap-4">
-                <Button size="lg" className="bg-primary hover:bg-primary/90">
-                  Request Demo
+                <Button
+                  size="lg"
+                  className="bg-primary hover:bg-primary/90"
+                  onClick={open}
+                >
+                  Request More Info
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </Button>
                 <Button asChild variant="secondary" size="lg">
@@ -468,6 +475,7 @@ function HomePage() {
 
 function Header() {
   const location = useLocation();
+  const { open } = useInfoRequest();
   
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -479,8 +487,8 @@ function Header() {
           <span className="text-xl font-bold text-primary">HiboCare</span>
         </Link>
         <nav className="hidden md:flex items-center space-x-6">
-          <Link 
-            to="/features" 
+          <Link
+            to="/features"
             className={`text-sm font-medium hover:text-primary transition-colors ${
               location.pathname === '/features' ? 'text-primary' : ''
             }`}
@@ -513,7 +521,15 @@ function Header() {
           </Link>
           <a href="#contact" className="text-sm font-medium hover:text-primary transition-colors">Contact</a>
         </nav>
-        {/* Removed quote button */}
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            open();
+          }}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+        >
+          Request More Info
+        </button>
       </div>
     </header>
   );
@@ -574,20 +590,23 @@ function Footer() {
 
 function App() {
   return (
-    <Router>
-      <ScrollHandler />
-      <div className="min-h-screen bg-background">
-        <Header />
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/features" element={<Features />} />
-          <Route path="/benefits" element={<Benefits />} />
-          <Route path="/technology" element={<Technology />} />
-          <Route path="/downloads" element={<DownloadsPage />} />
-        </Routes>
-        <Footer />
-      </div>
-    </Router>
+    <InfoRequestProvider>
+      <Router>
+        <ScrollHandler />
+        <div className="min-h-screen bg-background">
+          <Header />
+          <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route path="/features" element={<Features />} />
+            <Route path="/benefits" element={<Benefits />} />
+            <Route path="/technology" element={<Technology />} />
+            <Route path="/downloads" element={<DownloadsPage />} />
+          </Routes>
+          <Footer />
+        </div>
+        <InfoRequestModal />
+      </Router>
+    </InfoRequestProvider>
   );
 }
 

--- a/src/features/info/InfoRequestContext.tsx
+++ b/src/features/info/InfoRequestContext.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext, useState, useCallback, ReactNode } from "react";
+
+type Ctx = { open: () => void; close: () => void; isOpen: boolean };
+
+const InfoRequestCtx = createContext<Ctx | null>(null);
+
+export function InfoRequestProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  return (
+    <InfoRequestCtx.Provider value={{ open, close, isOpen }}>
+      {children}
+    </InfoRequestCtx.Provider>
+  );
+}
+
+export function useInfoRequest() {
+  const ctx = useContext(InfoRequestCtx);
+  if (!ctx) throw new Error("useInfoRequest must be used within InfoRequestProvider");
+  return ctx;
+}

--- a/src/features/info/InfoRequestModal.tsx
+++ b/src/features/info/InfoRequestModal.tsx
@@ -1,0 +1,215 @@
+import { useState } from "react";
+import { useInfoRequest } from "./InfoRequestContext";
+
+const AREAS = [
+  "Data Centers",
+  "Greenhouses & Grow Facilities",
+  "Hospitals",
+  "Commercial Buildings",
+];
+
+type State = "idle" | "sending" | "ok" | "error";
+
+export default function InfoRequestModal() {
+  const { isOpen, close } = useInfoRequest();
+  const endpoint =
+    import.meta.env.VITE_INFO_FORM_ENDPOINT || import.meta.env.VITE_FORM_ENDPOINT || "";
+
+  const [state, setState] = useState<State>("idle");
+  const [form, setForm] = useState({
+    area: AREAS[0],
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    notes: "",
+    company: "",
+    botField: "", // honeypot
+  });
+  const canSubmit = endpoint && state !== "sending";
+
+  const onChange =
+    (k: keyof typeof form) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+      setForm((f) => ({ ...f, [k]: e.target.value }));
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!endpoint) {
+      setState("error");
+      return;
+    }
+    if (form.botField) return; // ignore bots
+
+    setState("sending");
+    try {
+      const payload = {
+        area: form.area,
+        firstName: form.firstName,
+        lastName: form.lastName,
+        email: form.email,
+        phone: form.phone,
+        notes: form.notes,
+        company: form.company,
+        source_url: typeof window !== "undefined" ? window.location.href : "",
+      };
+
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (res.ok) {
+        setState("ok");
+      } else {
+        setState("error");
+      }
+    } catch {
+      setState("error");
+    }
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      aria-modal="true"
+      role="dialog"
+      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/50 px-4"
+      onClick={close}
+    >
+      <div
+        className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <h2 className="text-xl font-semibold">Request More Info</h2>
+          <button
+            onClick={close}
+            aria-label="Close"
+            className="rounded-full p-2 text-slate-500 hover:bg-slate-100"
+          >
+            ✕
+          </button>
+        </div>
+
+        {state === "ok" ? (
+          <div className="mt-4 rounded-lg bg-green-50 p-4 text-green-700">
+            Thank you! We’ve received your request and will get back to you shortly.
+          </div>
+        ) : state === "error" ? (
+          <div className="mt-4 rounded-lg bg-red-50 p-4 text-red-700">
+            Sorry, something went wrong. Please try again later.
+          </div>
+        ) : null}
+
+        <form onSubmit={onSubmit} className="mt-4 space-y-4">
+          {/* honeypot */}
+          <input
+            type="text"
+            name="botField"
+            autoComplete="off"
+            tabIndex={-1}
+            className="hidden"
+            value={form.botField}
+            onChange={onChange("botField")}
+          />
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <label className="mb-1 block text-sm font-medium">Area of interest</label>
+              <select
+                className="w-full rounded-lg border px-3 py-2"
+                value={form.area}
+                onChange={onChange("area")}
+                required
+              >
+                {AREAS.map((a) => (
+                  <option key={a} value={a}>
+                    {a}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium">First name</label>
+              <input
+                className="w-full rounded-lg border px-3 py-2"
+                value={form.firstName}
+                onChange={onChange("firstName")}
+                required
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Last name</label>
+              <input
+                className="w-full rounded-lg border px-3 py-2"
+                value={form.lastName}
+                onChange={onChange("lastName")}
+                required
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium">Email</label>
+              <input
+                type="email"
+                className="w-full rounded-lg border px-3 py-2"
+                value={form.email}
+                onChange={onChange("email")}
+                required
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Phone</label>
+              <input
+                type="tel"
+                className="w-full rounded-lg border px-3 py-2"
+                value={form.phone}
+                onChange={onChange("phone")}
+              />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="mb-1 block text-sm font-medium">
+                Notes (project details, questions, timing)
+              </label>
+              <textarea
+                rows={4}
+                className="w-full rounded-lg border px-3 py-2"
+                value={form.notes}
+                onChange={onChange("notes")}
+              />
+            </div>
+          </div>
+
+          <div className="mt-2 flex items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={close}
+              className="rounded-lg border px-4 py-2 text-slate-700 hover:bg-slate-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {state === "sending" ? "Sending…" : "Submit"}
+            </button>
+          </div>
+
+          {!endpoint && (
+            <p className="mt-2 text-xs text-slate-500">
+              (Admin note: set <code>VITE_INFO_FORM_ENDPOINT</code> in env, or we’ll fall
+              back to <code>VITE_FORM_ENDPOINT</code>.)
+            </p>
+          )}
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add environment var for info request form endpoint
- create InfoRequest context and modal with Formspree submit and honeypot
- wrap app with provider and modal; update header/hero buttons to open modal

## Testing
- `pnpm i`
- `pnpm run build`
- `pnpm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68b833de2efc832b993ffc528f512d52