### PR TITLE
feat: embed brochure viewer page

### DIFF
--- a/hibocare-website/src/App.jsx
+++ b/hibocare-website/src/App.jsx
@@ -9,6 +9,7 @@ import Features from './components/Features';
 import Benefits from './components/Benefits';
 import Technology from './components/Technology';
 import DownloadsPage from './pages/Downloads';
+import DocViewerPage from './pages/DocViewer';
 import DataCentersModal from './features/industries/DataCentersModal';
 import HospitalsModal from './features/industries/HospitalsModal';
 import GreenhousesModal from './features/industries/GreenhousesModal';
@@ -35,8 +36,6 @@ import {
 } from 'lucide-react';
 import filterImage from './assets/hibocare_filter_creative.png';
 import productImage from './assets/productshotH600.png';
-import lifestyleImage from './assets/HSlifestylephoto.jpg';
-import heroFiltersImage from './assets/hero_filters_original.jpeg';
 
 function HeroCTA() {
   const { openModal } = useInfoRequest();
@@ -587,6 +586,7 @@ function App() {
           <Route path="/benefits" element={<Benefits />} />
           <Route path="/technology" element={<Technology />} />
           <Route path="/downloads" element={<DownloadsPage />} />
+          <Route path="/docs/:slug" element={<DocViewerPage />} />
         </Routes>
         <Footer />
       </div>

--- a/hibocare-website/src/features/industries/DataCentersModal.jsx
+++ b/hibocare-website/src/features/industries/DataCentersModal.jsx
@@ -31,6 +31,7 @@ export default function DataCentersModal(props) {
         'Edge computing locations'
       ]}
       downloadLink="https://drive.google.com/file/d/1Vpb7o5ujuCzPezfRWICpel5YV2a53cO2/view?usp=sharing"
+      downloadTitle="Data Centers – Brochure"
       {...props}
     />
   );

--- a/hibocare-website/src/features/industries/GreenhousesModal.jsx
+++ b/hibocare-website/src/features/industries/GreenhousesModal.jsx
@@ -31,6 +31,7 @@ export default function GreenhousesModal(props) {
         'Research growth chambers'
       ]}
       downloadLink="https://drive.google.com/file/d/1L6Z5SYMTqh-w-vUJ0pjwXJeOfEI4dqbB/view?usp=sharing"
+      downloadTitle="Greenhouses & Grow Facilities – Brochure"
       {...props}
     />
   );

--- a/hibocare-website/src/features/industries/IndustryModal.jsx
+++ b/hibocare-website/src/features/industries/IndustryModal.jsx
@@ -1,9 +1,35 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Button } from '../../components/ui/button';
 import { Card, CardContent } from '../../components/ui/card';
 import { CheckCircle, ArrowRight } from 'lucide-react';
 
-export default function IndustryModal({ icon: Icon, title, subtitle, overview, keyBenefits, technicalSpecs, caseStudy, applications, onClose, downloadLink }) {
+const slugify = (value) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+
+const makeViewerPath = (title, url) =>
+  `/docs/${slugify(title)}?u=${encodeURIComponent(url)}&title=${encodeURIComponent(title)}`;
+
+export default function IndustryModal(props) {
+  const {
+    icon,
+    title,
+    subtitle,
+    overview,
+    keyBenefits,
+    technicalSpecs,
+    caseStudy,
+    applications,
+    onClose,
+    downloadLink,
+    downloadTitle,
+  } = props;
+  const IconComponent = icon;
+  const documentTitle = downloadTitle ?? `${title} — Document`;
+  const viewerLink = downloadLink ? makeViewerPath(documentTitle, downloadLink) : null;
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg max-w-4xl w-full max-h-[90vh] overflow-y-auto relative">
@@ -18,7 +44,7 @@ export default function IndustryModal({ icon: Icon, title, subtitle, overview, k
           <div className="flex items-start justify-between gap-4 flex-col sm:flex-row mb-6">
             <div className="flex items-center space-x-4">
               <div className="w-16 h-16 bg-primary/10 rounded-lg flex items-center justify-center">
-                <Icon className="h-8 w-8 text-primary" />
+                <IconComponent className="h-8 w-8 text-primary" />
               </div>
               <div className="space-y-1">
                 <h2 className="text-2xl font-bold">{title}</h2>
@@ -32,11 +58,11 @@ export default function IndustryModal({ icon: Icon, title, subtitle, overview, k
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </a>
               </Button>
-              {downloadLink ? (
+              {viewerLink ? (
                 <Button variant="outline" asChild>
-                  <a href={downloadLink} target="_blank" rel="noopener noreferrer">
+                  <Link to={viewerLink}>
                     Download Technical Specs
-                  </a>
+                  </Link>
                 </Button>
               ) : (
                 <Button variant="outline" disabled title="Specs coming soon">
@@ -109,4 +135,3 @@ export default function IndustryModal({ icon: Icon, title, subtitle, overview, k
     </div>
   );
 }
-

--- a/hibocare-website/src/pages/DocViewer.tsx
+++ b/hibocare-website/src/pages/DocViewer.tsx
@@ -1,0 +1,85 @@
+import { Link, useSearchParams } from "react-router-dom";
+
+function toPreview(raw: string) {
+  try {
+    const u = new URL(raw);
+    // Google Doc
+    if (u.hostname.includes("docs.google.com") && u.pathname.includes("/document/")) {
+      const id = u.pathname.split("/d/")[1]?.split("/")[0];
+      return id ? `https://docs.google.com/document/d/${id}/preview` : raw;
+    }
+    // Drive file link (/file/d/<id>/view|preview)
+    if (u.hostname.includes("drive.google.com") && u.pathname.includes("/file/")) {
+      const id = u.pathname.split("/d/")[1]?.split("/")[0];
+      return id ? `https://drive.google.com/file/d/${id}/preview` : raw;
+    }
+    // uc?export=download&id=<id>
+    if (u.hostname.includes("drive.google.com") && u.searchParams.get("id")) {
+      const id = u.searchParams.get("id")!;
+      return `https://drive.google.com/file/d/${id}/preview`;
+    }
+  } catch {}
+  return raw;
+}
+
+function toDownload(raw: string) {
+  try {
+    const u = new URL(raw);
+    if (u.hostname.includes("docs.google.com") && u.pathname.includes("/document/")) {
+      const id = u.pathname.split("/d/")[1]?.split("/")[0];
+      return id ? `https://docs.google.com/document/d/${id}/export?format=pdf` : raw;
+    }
+    if (u.hostname.includes("drive.google.com") && u.pathname.includes("/file/")) {
+      const id = u.pathname.split("/d/")[1]?.split("/")[0];
+      return id ? `https://drive.google.com/uc?export=download&id=${id}` : raw;
+    }
+    if (u.hostname.includes("drive.google.com") && u.searchParams.get("id")) {
+      const id = u.searchParams.get("id")!;
+      return `https://drive.google.com/uc?export=download&id=${id}`;
+    }
+  } catch {}
+  return raw;
+}
+
+function safeDecode(value: string | null): string {
+  if (!value) return "";
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export default function DocViewerPage() {
+  const [params] = useSearchParams();
+  const rawUrl = safeDecode(params.get("u"));
+  const title = safeDecode(params.get("title")) || "Document";
+
+  if (!rawUrl) {
+    return <div className="mx-auto max-w-5xl p-6">Missing document link.</div>;
+  }
+
+  const previewUrl = toPreview(rawUrl);
+  const downloadUrl = toDownload(rawUrl);
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <h1 className="text-2xl font-semibold">{title}</h1>
+      <div className="my-4 flex gap-3">
+        <a href={downloadUrl} className="rounded bg-blue-600 px-4 py-2 text-white">
+          Download PDF
+        </a>
+        <Link to="/downloads" className="rounded border px-4 py-2">
+          Back
+        </Link>
+      </div>
+      <iframe
+        src={previewUrl}
+        className="w-full"
+        style={{ height: "85vh", border: 0 }}
+        allow="fullscreen"
+        title={title}
+      />
+    </div>
+  );
+}

--- a/hibocare-website/src/pages/Downloads.tsx
+++ b/hibocare-website/src/pages/Downloads.tsx
@@ -81,6 +81,9 @@ const sections: Section[] = [
   },
 ];
 
+const makeViewerPath = (itemTitle: string, url: string) =>
+  `/docs/${slug(itemTitle)}?u=${encodeURIComponent(url)}&title=${encodeURIComponent(itemTitle)}`;
+
 export default function DownloadsPage() {
   return (
     <main className="mx-auto max-w-6xl px-4 py-12">
@@ -89,7 +92,7 @@ export default function DownloadsPage() {
         <h1 className="text-4xl font-bold tracking-tight">Downloads</h1>
         <p className="mt-3 text-lg text-muted-foreground">
           Specs, brochures, and reference docs for HiboScreen. Choose a resource below.
-          Brochures with links open in a new tab; other items are coming soon.
+          Linked brochures open inside our on-site viewer with a download option; other items are coming soon.
         </p>
       </header>
 
@@ -108,38 +111,45 @@ export default function DownloadsPage() {
                 {section.heading}
               </h2>
               <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {section.items.map((item, idx) => (
-                  <article
-                    key={`${section.heading}-${idx}`}
-                    className="rounded-2xl border bg-background p-5 shadow-sm transition hover:shadow"
-                  >
-                    <h3 className="text-base font-semibold">{item.title}</h3>
-                    {item.blurb && (
-                      <p className="mt-2 text-sm text-muted-foreground">{item.blurb}</p>
-                    )}
+                {section.items.map((item, idx) => {
+                  const linkLabel = item.title.toLowerCase().includes("brochure")
+                    ? "Open brochure"
+                    : "View document";
 
-                    <div className="mt-4">
-                      {item.href ? (
-                        <a
-                          href={item.href}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="inline-flex items-center rounded-lg bg-primary px-3 py-2 text-sm text-primary-foreground hover:opacity-90"
-                        >
-                          Download PDF
-                        </a>
-                      ) : (
-                        <button
-                          disabled
-                          title="Coming soon"
-                          className="inline-flex cursor-not-allowed items-center rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground"
-                        >
-                          Coming soon
-                        </button>
+                  return (
+                    <article
+                      key={`${section.heading}-${idx}`}
+                      className="rounded-2xl border bg-background p-5 shadow-sm transition hover:shadow"
+                    >
+                      <h3 className="text-base font-semibold">{item.title}</h3>
+                      {item.blurb && (
+                        <p className="mt-2 text-sm text-muted-foreground">{item.blurb}</p>
                       )}
-                    </div>
-                  </article>
-                ))}
+
+                      <div className="mt-4">
+                        {item.href ? (
+                          <Link
+                            to={makeViewerPath(item.title, item.href)}
+                            className={[
+                              "inline-flex items-center rounded-lg bg-primary px-3 py-2 text-sm text-primary-foreground",
+                              "hover:opacity-90",
+                            ].join(" ")}
+                          >
+                            {linkLabel}
+                          </Link>
+                        ) : (
+                          <button
+                            disabled
+                            title="Coming soon"
+                            className="inline-flex cursor-not-allowed items-center rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground"
+                          >
+                            Coming soon
+                          </button>
+                        )}
+                      </div>
+                    </article>
+                  );
+                })}
               </div>
             </section>
           );
@@ -148,4 +158,3 @@ export default function DownloadsPage() {
     </main>
   );
 }
-

--- a/hibocare-website/vite.config.js
+++ b/hibocare-website/vite.config.js
@@ -1,11 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import path from 'path'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(),tailwindcss()],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/src/features/industries/DataCentersModal.jsx
+++ b/src/features/industries/DataCentersModal.jsx
@@ -31,6 +31,7 @@ export default function DataCentersModal(props) {
         'Edge computing locations'
       ]}
       downloadLink="https://drive.google.com/file/d/1Vpb7o5ujuCzPezfRWICpel5YV2a53cO2/view?usp=sharing"
+      downloadTitle="Data Centers – Brochure"
       {...props}
     />
   );

--- a/src/features/industries/GreenhousesModal.jsx
+++ b/src/features/industries/GreenhousesModal.jsx
@@ -31,6 +31,7 @@ export default function GreenhousesModal(props) {
         'Research growth chambers'
       ]}
       downloadLink="https://drive.google.com/file/d/1L6Z5SYMTqh-w-vUJ0pjwXJeOfEI4dqbB/view?usp=sharing"
+      downloadTitle="Greenhouses & Grow Facilities – Brochure"
       {...props}
     />
   );

--- a/src/features/industries/IndustryModal.jsx
+++ b/src/features/industries/IndustryModal.jsx
@@ -1,7 +1,17 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Button } from '../../components/ui/button';
 import { Card, CardContent } from '../../components/ui/card';
 import { CheckCircle, ArrowRight } from 'lucide-react';
+
+const slugify = (value) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+
+const makeViewerPath = (title, url) =>
+  `/docs/${slugify(title)}?u=${encodeURIComponent(url)}&title=${encodeURIComponent(title)}`;
 
 export default function IndustryModal(props) {
   const {
@@ -15,8 +25,11 @@ export default function IndustryModal(props) {
     applications,
     onClose,
     downloadLink,
+    downloadTitle,
   } = props;
   const IconComponent = icon;
+  const documentTitle = downloadTitle ?? `${title} — Document`;
+  const viewerLink = downloadLink ? makeViewerPath(documentTitle, downloadLink) : null;
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg max-w-4xl w-full max-h-[90vh] overflow-y-auto relative">
@@ -45,11 +58,11 @@ export default function IndustryModal(props) {
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </a>
               </Button>
-              {downloadLink ? (
+              {viewerLink ? (
                 <Button variant="outline" asChild>
-                  <a href={downloadLink} target="_blank" rel="noopener noreferrer">
+                  <Link to={viewerLink}>
                     Download Technical Specs
-                  </a>
+                  </Link>
                 </Button>
               ) : (
                 <Button variant="outline" disabled title="Specs coming soon">

--- a/src/pages/DocViewer.tsx
+++ b/src/pages/DocViewer.tsx
@@ -1,21 +1,48 @@
-import { useEffect, useMemo } from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 
-type NormalizedLinks = {
-  previewUrl: string;
-  downloadUrl: string;
-};
+function toPreview(raw: string) {
+  try {
+    const u = new URL(raw);
+    // Google Doc
+    if (u.hostname.includes("docs.google.com") && u.pathname.includes("/document/")) {
+      const id = u.pathname.split("/d/")[1]?.split("/")[0];
+      return id ? `https://docs.google.com/document/d/${id}/preview` : raw;
+    }
+    // Drive file link (/file/d/<id>/view|preview)
+    if (u.hostname.includes("drive.google.com") && u.pathname.includes("/file/")) {
+      const id = u.pathname.split("/d/")[1]?.split("/")[0];
+      return id ? `https://drive.google.com/file/d/${id}/preview` : raw;
+    }
+    // uc?export=download&id=<id>
+    if (u.hostname.includes("drive.google.com") && u.searchParams.get("id")) {
+      const id = u.searchParams.get("id")!;
+      return `https://drive.google.com/file/d/${id}/preview`;
+    }
+  } catch {}
+  return raw;
+}
 
-type GoogleDocType = "document" | "spreadsheets" | "presentation";
+function toDownload(raw: string) {
+  try {
+    const u = new URL(raw);
+    if (u.hostname.includes("docs.google.com") && u.pathname.includes("/document/")) {
+      const id = u.pathname.split("/d/")[1]?.split("/")[0];
+      return id ? `https://docs.google.com/document/d/${id}/export?format=pdf` : raw;
+    }
+    if (u.hostname.includes("drive.google.com") && u.pathname.includes("/file/")) {
+      const id = u.pathname.split("/d/")[1]?.split("/")[0];
+      return id ? `https://drive.google.com/uc?export=download&id=${id}` : raw;
+    }
+    if (u.hostname.includes("drive.google.com") && u.searchParams.get("id")) {
+      const id = u.searchParams.get("id")!;
+      return `https://drive.google.com/uc?export=download&id=${id}`;
+    }
+  } catch {}
+  return raw;
+}
 
-const DOC_PREVIEW_SEGMENTS: Record<GoogleDocType, string> = {
-  document: "document",
-  spreadsheets: "spreadsheets",
-  presentation: "presentation",
-};
-
-function safeDecode(value: string | null | undefined): string | null {
-  if (!value) return null;
+function safeDecode(value: string | null): string {
+  if (!value) return "";
   try {
     return decodeURIComponent(value);
   } catch {
@@ -23,156 +50,36 @@ function safeDecode(value: string | null | undefined): string | null {
   }
 }
 
-function sanitizeGoogleId(candidate: string | null | undefined): string | null {
-  if (!candidate) return null;
-  const trimmed = candidate.trim();
-  return trimmed ? trimmed.replace(/[^a-zA-Z0-9_-]/g, "") : null;
-}
-
-function isHttpUrl(candidate: string | null): candidate is string {
-  if (!candidate) return false;
-  try {
-    const url = new URL(candidate);
-    return url.protocol === "https:" || url.protocol === "http:";
-  } catch {
-    return false;
-  }
-}
-
-function buildDocsUrls(id: string, type: GoogleDocType): NormalizedLinks {
-  const encodedId = encodeURIComponent(id);
-  const base = `https://docs.google.com/${DOC_PREVIEW_SEGMENTS[type]}/d/${encodedId}`;
-  const previewUrl = `${base}/preview`;
-  const downloadUrl =
-    type === "presentation"
-      ? `${base}/export/pdf`
-      : `${base}/export?format=pdf`;
-
-  return { previewUrl, downloadUrl };
-}
-
-function buildDriveUrls(id: string): NormalizedLinks {
-  const encodedId = encodeURIComponent(id);
-  return {
-    previewUrl: `https://drive.google.com/file/d/${encodedId}/preview`,
-    downloadUrl: `https://drive.google.com/uc?export=download&id=${encodedId}`,
-  };
-}
-
-function matchGoogleLinks(url: URL): NormalizedLinks | null {
-  const { host, pathname, searchParams } = url;
-  const fromPath = sanitizeGoogleId(pathname.match(/\/d\/([^/]+)/)?.[1]);
-  const fromQuery = sanitizeGoogleId(searchParams.get("id") ?? searchParams.get("file"));
-  const resourceId = fromPath ?? fromQuery;
-
-  if (!resourceId) {
-    return null;
-  }
-
-  if (host.includes("docs.google.com")) {
-    if (pathname.includes("/document/")) {
-      return buildDocsUrls(resourceId, "document");
-    }
-    if (pathname.includes("/spreadsheets/")) {
-      return buildDocsUrls(resourceId, "spreadsheets");
-    }
-    if (pathname.includes("/presentation/")) {
-      return buildDocsUrls(resourceId, "presentation");
-    }
-    if (pathname.startsWith("/uc")) {
-      return buildDriveUrls(resourceId);
-    }
-  }
-
-  if (host.includes("drive.google.com")) {
-    return buildDriveUrls(resourceId);
-  }
-
-  return null;
-}
-
-function normalizeLinks(rawUrl: string): NormalizedLinks | null {
-  try {
-    const parsed = new URL(rawUrl);
-    return matchGoogleLinks(parsed);
-  } catch {
-    return null;
-  }
-}
-
-function formatTitleFromSlug(slug?: string | null): string | null {
-  if (!slug) return null;
-  return slug
-    .split("-")
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
 export default function DocViewerPage() {
-  const { slug } = useParams<{ slug?: string }>();
-  const [searchParams] = useSearchParams();
-  const rawParam = searchParams.get("u");
-  const decodedUrl = safeDecode(rawParam);
+  const [params] = useSearchParams();
+  const rawUrl = safeDecode(params.get("u"));
+  const title = safeDecode(params.get("title")) || "Document";
 
-  if (!decodedUrl) {
-    return <div className="mx-auto max-w-5xl p-6">Missing document URL.</div>;
+  if (!rawUrl) {
+    return <div className="mx-auto max-w-5xl p-6">Missing document link.</div>;
   }
 
-  if (!isHttpUrl(decodedUrl)) {
-    return (
-      <div className="mx-auto max-w-5xl p-6">
-        Unsupported document URL. Please provide a valid https link.
-      </div>
-    );
-  }
-
-  const providedTitle = safeDecode(searchParams.get("title"));
-  const derivedTitle = providedTitle ?? formatTitleFromSlug(slug) ?? "Document";
-
-  const normalizedLinks = useMemo(() => normalizeLinks(decodedUrl), [decodedUrl]);
-  const previewUrl = normalizedLinks?.previewUrl ?? decodedUrl;
-  const downloadUrl = normalizedLinks?.downloadUrl ?? decodedUrl;
-  const isNormalized = Boolean(normalizedLinks);
-
-  useEffect(() => {
-    const originalTitle = document.title;
-    document.title = `${derivedTitle} | HiboCare`;
-    return () => {
-      document.title = originalTitle;
-    };
-  }, [derivedTitle]);
+  const previewUrl = toPreview(rawUrl);
+  const downloadUrl = toDownload(rawUrl);
 
   return (
-    <main className="mx-auto max-w-6xl p-6">
-      <h1 className="text-2xl font-semibold">{derivedTitle}</h1>
-      <div className="my-4 flex flex-wrap gap-3">
-        <a
-          href={downloadUrl}
-          className="inline-flex items-center rounded bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700"
-          target="_blank"
-          rel="noreferrer"
-        >
+    <div className="mx-auto max-w-6xl p-6">
+      <h1 className="text-2xl font-semibold">{title}</h1>
+      <div className="my-4 flex gap-3">
+        <a href={downloadUrl} className="rounded bg-blue-600 px-4 py-2 text-white">
           Download PDF
         </a>
-        <Link to="/downloads" className="inline-flex items-center rounded border px-4 py-2">
+        <Link to="/downloads" className="rounded border px-4 py-2">
           Back
         </Link>
-        {!isNormalized && (
-          <span className="inline-flex items-center text-sm text-muted-foreground">
-            This file opens directly from the original link.
-          </span>
-        )}
       </div>
-      <div className="overflow-hidden rounded-lg border bg-background">
-        <iframe
-          src={previewUrl}
-          title={derivedTitle}
-          className="h-[85vh] w-full"
-          loading="lazy"
-          allowFullScreen
-        />
-      </div>
-    </main>
+      <iframe
+        src={previewUrl}
+        className="w-full"
+        style={{ height: "85vh", border: 0 }}
+        allow="fullscreen"
+        title={title}
+      />
+    </div>
   );
 }

--- a/src/pages/Downloads.tsx
+++ b/src/pages/Downloads.tsx
@@ -130,7 +130,10 @@ export default function DownloadsPage() {
                         {item.href ? (
                           <Link
                             to={makeViewerPath(item.title, item.href)}
-                            className="inline-flex items-center rounded-lg bg-primary px-3 py-2 text-sm text-primary-foreground hover:opacity-90"
+                            className={[
+                              "inline-flex items-center rounded-lg bg-primary px-3 py-2 text-sm text-primary-foreground",
+                              "hover:opacity-90",
+                            ].join(" ")}
                           >
                             {linkLabel}
                           </Link>


### PR DESCRIPTION
## Summary
- replace the document viewer with an embedded Google preview and on-site download action
- point all brochure entries on the downloads page to the internal /docs/:slug route
- update industry modals to reuse the in-site viewer instead of opening new tabs

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68d404efd18c832bab9f7280fa6c2c26