### PR TITLE
Replace HiBoAir logo with stable icon sizing

### DIFF
--- a/hibocare-website/src/App.jsx
+++ b/hibocare-website/src/App.jsx
@@ -5,7 +5,6 @@ import './App.css';
 import { Button } from './components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './components/ui/card';
 import { Badge } from './components/ui/badge';
-import hiboAirLogo from './assets/hiboair-logo.svg';
 import Features from './components/Features';
 import Benefits from './components/Benefits';
 import Technology from './components/Technology';
@@ -501,9 +500,15 @@ function Header() {
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 items-center justify-between gap-4">
         <div className="flex items-center gap-6">
-          <Link to="/" className="inline-flex items-center">
-            <img src={hiboAirLogo} alt="HiBoAir" className="h-10 w-auto" />
-            <span className="sr-only">HiBoAir home</span>
+          <Link to="/" className="flex items-center gap-2" aria-label="HiBoAir Home">
+            <img
+              src="https://drive.google.com/uc?export=download&id=15aQnumSd-ez8iQiY9AkzsB4n2zKnFALm"
+              alt="HiBoAir"
+              className="h-8 w-auto"
+              loading="eager"
+              decoding="sync"
+            />
+            <span className="font-semibold text-slate-900">HiBoAir</span>
           </Link>
           <nav className="hidden md:flex items-center space-x-6">
             <Link
@@ -558,9 +563,13 @@ function Footer() {
       <div className="container mx-auto px-4">
         <div className="grid md:grid-cols-4 gap-8">
           <div className="space-y-4">
-            <Link to="/" className="inline-flex items-center">
-              <img src={hiboAirLogo} alt="HiBoAir" className="h-10 w-auto" />
-              <span className="sr-only">HiBoAir home</span>
+            <Link to="/" className="flex items-center gap-3" aria-label="HiBoAir Home">
+              <img
+                src="https://drive.google.com/uc?export=download&id=15aQnumSd-ez8iQiY9AkzsB4n2zKnFALm"
+                alt="HiBoAir"
+                className="h-7 w-auto"
+              />
+              <span className="text-slate-200">HiBoAir</span>
             </Link>
             <p className="text-gray-400 text-sm">
               Clean Air, Green Buildings, Healthy Spaces

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,6 @@ import './App.css';
 import { Button } from './components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './components/ui/card';
 import { Badge } from './components/ui/badge';
-import hiboAirLogo from './assets/hiboair-logo.svg';
 import Features from './components/Features';
 import Benefits from './components/Benefits';
 import Technology from './components/Technology';
@@ -501,9 +500,15 @@ function Header() {
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 items-center justify-between gap-4">
         <div className="flex items-center gap-6">
-          <Link to="/" className="inline-flex items-center">
-            <img src={hiboAirLogo} alt="HiBoAir" className="h-10 w-auto" />
-            <span className="sr-only">HiBoAir home</span>
+          <Link to="/" className="flex items-center gap-2" aria-label="HiBoAir Home">
+            <img
+              src="https://drive.google.com/uc?export=download&id=15aQnumSd-ez8iQiY9AkzsB4n2zKnFALm"
+              alt="HiBoAir"
+              className="h-8 w-auto"
+              loading="eager"
+              decoding="sync"
+            />
+            <span className="font-semibold text-slate-900">HiBoAir</span>
           </Link>
           <nav className="hidden md:flex items-center space-x-6">
             <Link
@@ -558,9 +563,13 @@ function Footer() {
       <div className="container mx-auto px-4">
         <div className="grid md:grid-cols-4 gap-8">
           <div className="space-y-4">
-            <Link to="/" className="inline-flex items-center">
-              <img src={hiboAirLogo} alt="HiBoAir" className="h-10 w-auto" />
-              <span className="sr-only">HiBoAir home</span>
+            <Link to="/" className="flex items-center gap-3" aria-label="HiBoAir Home">
+              <img
+                src="https://drive.google.com/uc?export=download&id=15aQnumSd-ez8iQiY9AkzsB4n2zKnFALm"
+                alt="HiBoAir"
+                className="h-7 w-auto"
+              />
+              <span className="text-slate-200">HiBoAir</span>
             </Link>
             <p className="text-gray-400 text-sm">
               Clean Air, Green Buildings, Healthy Spaces


### PR DESCRIPTION
## Summary
- replace header logo with stable HiBoAir icon URL at a fixed 32px height
- update footer logo to the same source at a consistent 28-32px height
- remove unused local logo import now that remote asset is in use

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcb0322838832b994c6b025ceea21d